### PR TITLE
Fix link colors in dark mode

### DIFF
--- a/pages/talks.tsx
+++ b/pages/talks.tsx
@@ -10,6 +10,8 @@ import { Talks } from '../Data';
 
 const cardDark = '#222426';
 const cardLight = '#fff';
+const titleDark = '#fff';
+const titleLight = 'blue';
 
 const Text = RNText as any;
 
@@ -29,6 +31,10 @@ function TalkCardPresentationRow({
 
   const link = React.useRef(null);
   const { isHovered } = useHover(link);
+  const titleColor = isDark ? titleDark : titleLight;
+
+  // Intetionally inverted
+  const cardColor = isDark ? cardLight : cardDark;
 
   return (
     <View>
@@ -38,15 +44,17 @@ function TalkCardPresentationRow({
           target="_blank"
           accessibilityRole="link"
           href={href}
-          style={[styles.presTitle, isHovered && { borderBottomColor: 'blue' }]}
+          style={[
+            styles.presTitle,
+            {
+              color: titleColor,
+              borderBottomColor: isHovered ? titleColor : 'transparent',
+            },
+          ]}
         >
           {title}
         </Text>
-        {date && (
-          <Text style={{ color: isDark ? cardLight : cardDark, fontSize: 18 }}>
-            {date}
-          </Text>
-        )}
+        {date && <Text style={{ color: cardColor, fontSize: 18 }}>{date}</Text>}
       </View>
 
       {!!resources.length && (

--- a/pages/talks.tsx
+++ b/pages/talks.tsx
@@ -10,7 +10,7 @@ import { Talks } from '../Data';
 
 const cardDark = '#222426';
 const cardLight = '#fff';
-const titleDark = '#fff';
+const titleDark = 'rgb(158, 231, 255)';
 const titleLight = 'blue';
 
 const Text = RNText as any;


### PR DESCRIPTION
It's hard to see the `blue` text in links in dark mode, so use a light blue instead.

# Before

![Screen Shot 2020-02-11 at 14 32 20](https://user-images.githubusercontent.com/90494/74285793-5d97ce00-4cdb-11ea-89f7-8625a1f3fb75.png)

# After

![Screen Shot 2020-02-11 at 14 32 32](https://user-images.githubusercontent.com/90494/74285799-61c3eb80-4cdb-11ea-867b-03b5c85c3962.png)
