### PR TITLE
Migrate blog routes to use Expo data loaders

### DIFF
--- a/app.json
+++ b/app.json
@@ -48,7 +48,8 @@
         {
           "origin": "",
           "headOrigin": "https://evanbacon.dev",
-          "asyncRoutes": true
+          "asyncRoutes": true,
+          "unstable_useServerDataLoaders": true
         }
       ],
       "expo-quick-actions",

--- a/src/app/(app)/blog/[post].tsx
+++ b/src/app/(app)/blog/[post].tsx
@@ -4,18 +4,10 @@ import { useFont } from '@/components/useFont';
 import { useIsFullScreenRoute } from '@/components/useIsFullScreenRoute';
 import { LD_EVAN_BACON } from '@/data/structured';
 import { resolveAssetUri } from '@/utils/resolveMetroAsset';
-import { router, Stack, useLocalSearchParams, usePathname } from 'expo-router';
+import { router, Stack, useLoaderData, usePathname } from 'expo-router';
 import Head from 'expo-router/head';
 import React from 'react';
 import { Clipboard, Text } from 'react-native';
-
-export async function generateStaticParams(): Promise<{ post: string }[]> {
-  return mdxctx
-    .keys()
-    .filter(i => i.match(/\.js$/))
-    .map(key => mdxctx(key).slug)
-    .map(post => ({ post }));
-}
 
 const mdxctx = require.context('../../../../blog', true, /\.(mdx|js)$/);
 
@@ -28,29 +20,30 @@ type PostInfo = {
   featuredImage: number;
 };
 
-function useData(
-  postId: string
-): null | {
-  MarkdownComponent: any;
-  info: PostInfo;
-} {
-  const MDKey = React.useMemo(
-    () => mdxctx.keys().find(p => p === './' + postId + '/index.mdx'),
-    [postId]
-  );
+export async function generateStaticParams(): Promise<{ post: string }[]> {
+  return mdxctx
+    .keys()
+    .filter(i => i.match(/\.js$/))
+    .map(key => mdxctx(key).slug)
+    .map(post => ({ post }));
+}
 
-  const mdinfo = React.useMemo(
-    () => mdxctx.keys().find(p => p === './' + postId + '/index.js'),
-    [postId]
-  );
+export async function loader(
+  _request: unknown,
+  params: { post: string }
+): Promise<{ info: PostInfo; postId: string } | null> {
+  let postId = params.post;
+  if (postId === 'expo-2024') {
+    postId = 'expo-apps';
+  }
 
-  const MD = MDKey ? mdxctx(MDKey).default : null;
-  const Info = mdinfo ? mdxctx(mdinfo) : null;
-
-  if (!MD || !Info) {
+  const mdinfo = mdxctx.keys().find(p => p === './' + postId + '/index.js');
+  if (!mdinfo) {
     return null;
   }
-  return { MarkdownComponent: MD, info: Info };
+
+  const info = mdxctx(mdinfo) as PostInfo;
+  return { info, postId };
 }
 
 function BlogHead({ info }: { info: PostInfo }) {
@@ -102,21 +95,16 @@ function BlogHead({ info }: { info: PostInfo }) {
 }
 
 export default function Page() {
-  let { post: postId } = useLocalSearchParams<{ post: string }>();
-  if (postId === 'expo-2024') {
-    postId = 'expo-apps';
-  }
+  const data = useLoaderData<typeof loader>();
   const isFullScreen = useIsFullScreenRoute();
-  const data = useData(postId);
   const Inter_900Black = useFont('Inter_900Black');
-
   const paddingBottom = useBottomTabOverflow();
 
   if (!data) {
-    return <Text>Not Found: {postId}</Text>;
+    return <Text>Not Found</Text>;
   }
 
-  const { info } = data;
+  const { info, postId } = data;
 
   return (
     <>

--- a/src/app/(app)/blog/index.tsx
+++ b/src/app/(app)/blog/index.tsx
@@ -3,39 +3,49 @@ import '../../../../global.css';
 import PageHeader from '@/components/PageHeader';
 import { useBottomTabOverflow } from '@/components/ui/TabBarBackground';
 import { B, Div, LI, Span, UL } from '@expo/html-elements';
-import { Link } from 'expo-router';
+import { Link, useLoaderData } from 'expo-router';
 import { ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
 
 type DataType = {
   title: string;
   description: string;
   value: string;
+  date: string;
   href: string;
 };
 
 const mdxctx = require.context('../../../../blog', true, /\.(mdx|js)$/);
 
-const posts = mdxctx
-  .keys()
-  .filter(i => i.match(/\.js$/))
-  .map(key => mdxctx(key));
+export async function loader(
+  _request: unknown,
+  _params: Record<string, string>
+): Promise<{ posts: DataType[] }> {
+  const posts = mdxctx
+    .keys()
+    .filter(i => i.match(/\.js$/))
+    .map(key => mdxctx(key));
 
-const POSTS = posts
-  .map(({ title, shortTitle, subtitle, date, slug }) => ({
-    title: shortTitle ?? title,
-    description: subtitle,
-    value: new Date(date).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    }),
-    date,
-    href: `/blog/${slug}`,
-  }))
-  .sort((a, b) => b.date.localeCompare(a.date));
+  const formattedPosts = posts
+    .map(({ title, shortTitle, subtitle, date, slug }) => ({
+      title: shortTitle ?? title,
+      description: subtitle,
+      value: new Date(date).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      }),
+      date,
+      href: `/blog/${slug}`,
+    }))
+    .sort((a, b) => b.date.localeCompare(a.date));
+
+  return { posts: formattedPosts };
+}
 
 export default function App() {
+  const { posts } = useLoaderData<typeof loader>();
   const paddingBottom = useBottomTabOverflow();
+
   if (process.env.EXPO_OS === 'web') {
     return (
       <div className="flex flex-1 flex-col gap-4 overflow-x-hidden">
@@ -43,7 +53,7 @@ export default function App() {
 
         <div className="mt-8 space-y-6">
           <ul className="divide-y divide-slate-800/50">
-            {POSTS.map((item, index) => (
+            {posts.map((item, index) => (
               <li key={index} className="py-4">
                 <LineItem key={index} {...item} />
               </li>
@@ -73,7 +83,7 @@ export default function App() {
 
       <Div className="mt-8 space-y-6">
         <UL className="divide-y divide-slate-800/50">
-          {POSTS.map((item, index) => (
+          {posts.map((item, index) => (
             <LI key={index} className="py-4">
               <LineItemNative key={index} {...item} />
             </LI>


### PR DESCRIPTION
Upgrade the MDX/SSG blog pages to use Expo Router's new data loaders API. This moves data fetching to loader functions that run at build time for SSG, providing a cleaner separation between data loading and rendering.

- Enable `unstable_useServerDataLoaders` in app.json
- Add loader functions to blog/[post].tsx and blog/index.tsx
- Replace useData hook and module-level data with useLoaderData
- Keep generateStaticParams for SSG support